### PR TITLE
Adds support for Lists of Friends

### DIFF
--- a/friends/admin.py
+++ b/friends/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from friends.models import Friendship, FriendshipInvitation, Blocking
+from friends.models import Friendship, FriendshipInvitation, Blocking, FriendList
 
 
 class FriendshipAdmin(admin.ModelAdmin):
@@ -14,7 +14,15 @@ class FriendshipInvitationAdmin(admin.ModelAdmin):
 class BlockingAdmin(admin.ModelAdmin):
     list_display = ["id", "from_user", "to_user", "added"]
 
+class FriendListAdmin(admin.ModelAdmin):
+    list_display = ["id", "title", "owner"]
+    list_display_links = ["id", "title"]
+    filter_horizontal = ["friends"]
+    search_fields = ["^owner__username", "^title"]
+    readonly_fields = ["owner"]
+
 
 admin.site.register(Friendship, FriendshipAdmin)
 admin.site.register(FriendshipInvitation, FriendshipInvitationAdmin)
 admin.site.register(Blocking, BlockingAdmin)
+admin.site.register(FriendList, FriendListAdmin)

--- a/friends/fixtures/friends_test_fixture.json
+++ b/friends/fixtures/friends_test_fixture.json
@@ -1,0 +1,255 @@
+[
+    {
+        "pk": 1,
+        "model": "auth.user",
+        "fields": {
+            "username": "user1",
+            "first_name": "",
+            "last_name": "",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": false,
+            "last_login": "2012-07-20T17:05:23.922Z",
+            "groups": [],
+            "user_permissions": [],
+            "password": "",
+            "email": "",
+            "date_joined": "2012-07-20T17:05:23.922Z"
+        }
+    },
+    {
+        "pk": 2,
+        "model": "auth.user",
+        "fields": {
+            "username": "user2",
+            "first_name": "",
+            "last_name": "",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": false,
+            "last_login": "2012-07-20T17:05:24.105Z",
+            "groups": [],
+            "user_permissions": [],
+            "password": "",
+            "email": "",
+            "date_joined": "2012-07-20T17:05:24.105Z"
+        }
+    },
+    {
+        "pk": 3,
+        "model": "auth.user",
+        "fields": {
+            "username": "user3",
+            "first_name": "",
+            "last_name": "",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": false,
+            "last_login": "2012-07-20T17:05:24.110Z",
+            "groups": [],
+            "user_permissions": [],
+            "password": "",
+            "email": "",
+            "date_joined": "2012-07-20T17:05:24.110Z"
+        }
+    },
+    {
+        "pk": 4,
+        "model": "auth.user",
+        "fields": {
+            "username": "user4",
+            "first_name": "",
+            "last_name": "",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": false,
+            "last_login": "2012-07-20T17:05:24.114Z",
+            "groups": [],
+            "user_permissions": [],
+            "password": "",
+            "email": "",
+            "date_joined": "2012-07-20T17:05:24.114Z"
+        }
+    },
+    {
+        "pk": 5,
+        "model": "auth.user",
+        "fields": {
+            "username": "user5",
+            "first_name": "",
+            "last_name": "",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": false,
+            "last_login": "2012-07-20T17:05:24.118Z",
+            "groups": [],
+            "user_permissions": [],
+            "password": "",
+            "email": "",
+            "date_joined": "2012-07-20T17:05:24.118Z"
+        }
+    },
+    {
+        "pk": 6,
+        "model": "auth.user",
+        "fields": {
+            "username": "user6",
+            "first_name": "",
+            "last_name": "",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": false,
+            "last_login": "2012-07-20T17:05:24.123Z",
+            "groups": [],
+            "user_permissions": [],
+            "password": "",
+            "email": "",
+            "date_joined": "2012-07-20T17:05:24.123Z"
+        }
+    },
+    {
+        "pk": 7,
+        "model": "auth.user",
+        "fields": {
+            "username": "user7",
+            "first_name": "",
+            "last_name": "",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": false,
+            "last_login": "2012-07-20T17:05:24.127Z",
+            "groups": [],
+            "user_permissions": [],
+            "password": "",
+            "email": "",
+            "date_joined": "2012-07-20T17:05:24.127Z"
+        }
+    },
+    {
+        "pk": 8,
+        "model": "auth.user",
+        "fields": {
+            "username": "user8",
+            "first_name": "",
+            "last_name": "",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": false,
+            "last_login": "2012-07-20T17:05:24.132Z",
+            "groups": [],
+            "user_permissions": [],
+            "password": "",
+            "email": "",
+            "date_joined": "2012-07-20T17:05:24.132Z"
+        }
+    },
+    {
+        "pk": 9,
+        "model": "auth.user",
+        "fields": {
+            "username": "user9",
+            "first_name": "",
+            "last_name": "",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": false,
+            "last_login": "2012-07-20T17:05:24.136Z",
+            "groups": [],
+            "user_permissions": [],
+            "password": "",
+            "email": "",
+            "date_joined": "2012-07-20T17:05:24.136Z"
+        }
+    },
+    {
+        "pk": 10,
+        "model": "auth.user",
+        "fields": {
+            "username": "user10",
+            "first_name": "",
+            "last_name": "",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": false,
+            "last_login": "2012-07-20T17:05:24.141Z",
+            "groups": [],
+            "user_permissions": [],
+            "password": "",
+            "email": "",
+            "date_joined": "2012-07-20T17:05:24.141Z"
+        }
+    },
+    {
+        "pk": 2,
+        "model": "friends.friendship",
+        "fields": {
+            "to_user": 2,
+            "added": "2012-07-20T17:06:57.460Z",
+            "from_user": 1
+        }
+    },
+    {
+        "pk": 3,
+        "model": "friends.friendship",
+        "fields": {
+            "to_user": 3,
+            "added": "2012-07-20T17:06:57.464Z",
+            "from_user": 1
+        }
+    },
+    {
+        "pk": 4,
+        "model": "friends.friendship",
+        "fields": {
+            "to_user": 4,
+            "added": "2012-07-20T17:06:57.468Z",
+            "from_user": 1
+        }
+    },
+    {
+        "pk": 5,
+        "model": "friends.friendship",
+        "fields": {
+            "to_user": 1,
+            "added": "2012-07-20T17:07:35.604Z",
+            "from_user": 5
+        }
+    },
+    {
+        "pk": 6,
+        "model": "friends.friendship",
+        "fields": {
+            "to_user": 1,
+            "added": "2012-07-20T17:07:35.609Z",
+            "from_user": 6
+        }
+    },
+    {
+        "pk": 7,
+        "model": "friends.friendship",
+        "fields": {
+            "to_user": 1,
+            "added": "2012-07-20T17:07:35.614Z",
+            "from_user": 7
+        }
+    },
+    {
+        "pk": 1,
+        "model": "friends.blocking",
+        "fields": {
+            "to_user": 1,
+            "added": "2012-07-20T17:09:04.754Z",
+            "from_user": 10
+        }
+    },
+    {
+        "pk": 1,
+        "model": "friends.friendlist",
+        "fields": {
+            "owner": 1,
+            "created": "2012-07-20T17:08:08.871Z",
+            "friends": [],
+            "title": "test-list"
+        }
+    }
+]

--- a/friends/migrations/0003_auto__add_friendlist.py
+++ b/friends/migrations/0003_auto__add_friendlist.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'FriendList'
+        db.create_table('friends_friendlist', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('title', self.gf('django.db.models.fields.CharField')(max_length=100)),
+            ('created', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
+            ('owner', self.gf('django.db.models.fields.related.ForeignKey')(related_name='lists', to=orm['auth.User'])),
+        ))
+        db.send_create_signal('friends', ['FriendList'])
+
+        # Adding M2M table for field friends on 'FriendList'
+        db.create_table('friends_friendlist_friends', (
+            ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True)),
+            ('friendlist', models.ForeignKey(orm['friends.friendlist'], null=False)),
+            ('user', models.ForeignKey(orm['auth.user'], null=False))
+        ))
+        db.create_unique('friends_friendlist_friends', ['friendlist_id', 'user_id'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'FriendList'
+        db.delete_table('friends_friendlist')
+
+        # Removing M2M table for field friends on 'FriendList'
+        db.delete_table('friends_friendlist_friends')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'friends.blocking': {
+            'Meta': {'object_name': 'Blocking'},
+            'added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2012, 7, 20, 0, 0)'}),
+            'from_user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'blocking'", 'to': "orm['auth.User']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'to_user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'blocked_by'", 'to': "orm['auth.User']"})
+        },
+        'friends.friendlist': {
+            'Meta': {'object_name': 'FriendList'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'friends': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.User']", 'symmetrical': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'lists'", 'to': "orm['auth.User']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'friends.friendship': {
+            'Meta': {'unique_together': "[('to_user', 'from_user')]", 'object_name': 'Friendship'},
+            'added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2012, 7, 20, 0, 0)'}),
+            'from_user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'_unused_'", 'to': "orm['auth.User']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'to_user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'friends'", 'to': "orm['auth.User']"})
+        },
+        'friends.friendshipinvitation': {
+            'Meta': {'object_name': 'FriendshipInvitation'},
+            'from_user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'invitations_from'", 'to': "orm['auth.User']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {}),
+            'sent': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2012, 7, 20, 0, 0)'}),
+            'to_user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'invitations_to'", 'to': "orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['friends']

--- a/friends/tests/__init__.py
+++ b/friends/tests/__init__.py
@@ -1,0 +1,1 @@
+from list_tests import *

--- a/friends/tests/list_tests.py
+++ b/friends/tests/list_tests.py
@@ -1,0 +1,70 @@
+"""
+The test fixture contains the following users:
+
+In [8]: for u in User.objects.all(): print u.id, u.username
+1 user1
+2 user2
+3 user3
+4 user4
+5 user5
+6 user6
+7 user7
+8 user8
+9 user9
+10 user10
+
+In [9]: for f in Friendship.objects.all(): print f.id, f.from_user, f.to_user
+2 user1 user2
+3 user1 user3
+4 user1 user4
+5 user5 user1
+6 user6 user1
+7 user7 user1
+
+In [10]: for l in FriendList.objects.all(): print l.id, l.owner, l.friends.all()
+1 user1 []
+
+In [11]: for b in Blocking.objects.all(): print b.id, b.from_user, b.to_user
+1 user10 user1
+
+"""
+from operator import attrgetter
+from django.test import TestCase
+from django.db.models import Q
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
+
+from friends.models import Friendship, FriendList
+
+
+def sort_list(the_list, attr='id'):
+    the_list.sort(key=attrgetter(attr))
+
+
+class ListTestCase(TestCase):
+    fixtures = ['friends_test_fixture.json']
+    
+    def setUp(self):
+        self.user1 = User.objects.get(username='user1')
+        self.user1_list = FriendList.objects.get(owner=self.user1)
+    
+    def test_can_add_friend(self):
+        friend = User.objects.get(id=2)
+        original_count = self.user1_list.friends.all().count()
+        self.user1_list.friends.add(friend)
+        new_count = self.user1_list.friends.all().count()
+        self.assertTrue(friend in self.user1_list.friends.all())
+        self.assertEquals(original_count + 1, new_count)
+    
+    def test_cannot_add_non_friends(self):
+        non_friend = User.objects.get(id=8)
+        self.assertRaises(ValidationError, self.user1_list.friends.add, non_friend)
+    
+    def test_remove_from_list_when_deleting_friendship(self):
+        friend = User.objects.get(id=2)
+        self.user1_list.friends.add(friend)
+        friendship = Friendship.objects.get(id=2)
+        friendship.delete()
+        self.assertTrue(friend not in self.user1_list.friends.all())
+        
+        


### PR DESCRIPTION
If you're interested, I've added support for Facebook-style Friend lists. I'm intending to use this to allow users to share content to a list, rather than having to share content to individual friends.

It's implemented as a simple M2M to User, with some signals to make sure that non-friends are not added to the list, and to delete friends from lists when the friendship is deleted. It's designed in this way to make reading the friends list (the most frequent operation) as cheap as possible.

It's just models and tests at this point, no views (mine is an API driven site, so I don't have much use for views).

Tests included.
